### PR TITLE
Heroku related fixes

### DIFF
--- a/client/main.mjs
+++ b/client/main.mjs
@@ -18,7 +18,7 @@ function onTextKeyDown(event)
 function onAppVersionChanged(event)
 {
     const clientVersion = event.target.value;
-    const newClientUrl = `http://localhost:8088/client_versions/${ clientVersion }/main.html`;
+    const newClientUrl = `${window.location.protocol}//${window.location.host}/client_versions/${clientVersion}/main.html`;
     // redirect to the new URL
     window.location.href = newClientUrl;
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "ISC",
   "scripts": {
     "start": "npx tsx server/index.ts",
-    "heroku-postbuild": "bash ./scripts/build-all.sh"
+    "heroku-postbuild": "bash ./scripts/fetch-latest-frontend-versions.sh"
   },
   "engines": {
     "node": "22.x"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "start": "npx tsx server/index.ts",
     "heroku-postbuild": "bash ./scripts/build-all.sh"
   },
+  "engines": {
+    "node": "22.x"
+  },
   "dependencies": {
     "ejs": "^3.1.10",
     "express": "^5.1.0",

--- a/scripts/fetch-latest-frontend-versions.sh
+++ b/scripts/fetch-latest-frontend-versions.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+curl -L https://github.com/ferenk/nodejs_multi-version-support/releases/download/latest/client_versions.tar.bz2 -o client_versions.tar.bz2
+tar -xjf client_versions.tar.bz2
+rm client_versions.tar.bz2

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,9 @@ const express = require('express');
 import { Request, Response, Application, NextFunction } from 'express';
 
 var app: Application = express();
-const PORT = 8088;
+
+const DEfAULT_WEB_PORT = 8088;
+const PORT = process.env.PORT || DEfAULT_WEB_PORT;
 
 const path = require('path');
 


### PR DESCRIPTION
Changes integrated:
* Fixed service URL in the redirection. Not "localhost" but window.location
* Heroku express startup: port number is Heroku's port OR 8088
* Get old "client" binary folders as a pre-prepared archive from GitHub
  (Heroku doesn't give us the git repo's working copy during deploy)
* Heroku: Node.js version setting in package.json (requirement)
